### PR TITLE
selectではなくspanにして、touchendでトランジッションをきりかえる

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -519,7 +519,7 @@ app detail
   background-color: #000; }
   .photo_detail .detail_header {
     padding: 10px; }
-    .photo_detail .detail_header select {
+    .photo_detail .detail_header #transition_selection {
       width: 100px;
       font-size: 14px;
       font-family: DIN Light, sans-serif;
@@ -531,8 +531,8 @@ app detail
       border-radius: 4px;
       color: white;
       position: relative; }
-      .photo_detail .detail_header select::after {
-        content: "aaa";
+      .photo_detail .detail_header #transition_selection::after {
+        content: " ";
         color: white;
         position: absolute;
         right: 5px;

--- a/js/app.js
+++ b/js/app.js
@@ -35,7 +35,24 @@ var temps_data = [
 	{"temp": 20, "time": 3}
 ];
 
+var transition_types = [
+	'bars',
+	'blinds',
+	'blocks',
+	'blocks2',
+	'concentric',
+	'slide',
+	'warp',
+	'zip',
+	'bars3d',
+	'blinds3d',
+	'cube',
+	'tiles3d',
+	'turn'
+];
+
 var transition_type = "bars";
+var transtion_type_index = 0;
 
 var slider;
 var startX = 0;
@@ -54,6 +71,24 @@ function initSlider () {
 		slider.showImage(index, transition_type);
 		event.preventDefault();
 	});
+
+	var select = $('#transition_type');
+	select.on('touchend', function() {
+		var evt = document.createEvent('MouseEvents');
+		evt.initEvent('mousedown', false, true);
+		document.getElementById('transition_type').dispatchEvent(evt);
+	});
+
+	$('#transition_selection').on('touchend', function() {
+		if (transtion_type_index < transition_types.length -1) {
+			transtion_type_index += 1;
+		} else {
+			transtion_type_index = 0;
+		}
+		transition_type = transition_types[transtion_type_index];
+		$('#transition_selection').text(transition_type);
+	});
+
 }
 
 $(".ctrl_btns li, .touchmonth_li, .chart_panel, .app_photo").on("touchstart", function (e) {
@@ -155,5 +190,6 @@ $('main').on('touchmove', function(e) {
 $('main').on('touchend', function() {
 	//do nothing
 });
+
 
 // chart

--- a/photo_viewer.html
+++ b/photo_viewer.html
@@ -22,21 +22,7 @@
 					<header class="detail_header">
 						<div class="transition_selector">
 							<span>Transition</span>
-							<select name="transition_type" id="transition_type">
-								<option value="bars">bars</option>
-								<option value="blinds">blinds</option>
-								<option value="blocks">blocks</option>
-								<option value="blocks2">blocks2</option>
-								<option value="concentric">concentric</option>
-								<option value="slide">slide</option>
-								<option value="warp">warp</option>
-								<option value="zip">zip</option>
-								<option value="bars3d">bars3d</option>
-								<option value="blinds3d">blinds3d</option>
-								<option value="cube">cube</option>
-								<option value="tiles3d">tiles3d</option>
-								<option value="turn">turn</option>
-							</select>
+							<span id="transition_selection">bars</span>
 						</div>
 						<div class="header_close_btn"><i class="fa fa-times" aria-hidden="true"></i></div>
 					</header>

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -611,7 +611,7 @@ app detail
 .photo_detail {
 	.detail_header {
 		padding: 10px;
-		select {
+		#transition_selection {
 			width: 100px;
 			font-size: 14px;
 			font-family: DIN Light, sans-serif;
@@ -624,7 +624,7 @@ app detail
 			color: white;
 			position: relative;
 			&::after {
-				content: "aaa";
+				content: " ";
 				color: white;
 				position: absolute;
 				right: 5px;


### PR DESCRIPTION
#6 に関して。

select要素はネイティブのclickが発生しないとプルダウンしないため、
clickイベントが発生しない現在はプルダウンしない。
たとえば $('select').click() でもプルダウンしない。

そのため、spanに置き換え、そこにイベントハンドラーをbindし、
touchendで別のtransitionに切り替わるようにした。
transitionの種類は順番に切り替わる。
