### PR TITLE
expand close button on global header.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -123,7 +123,7 @@ ul, li, dl, dt, dd {
       margin-left: 1rem; }
   .global_header .header_close_btn {
     position: absolute;
-    right: 10px;
+    right: 20px;
     top: 10px;
     font-size: 26px;
     display: none; }

--- a/css/style.css
+++ b/css/style.css
@@ -123,8 +123,9 @@ ul, li, dl, dt, dd {
       margin-left: 1rem; }
   .global_header .header_close_btn {
     position: absolute;
-    right: 20px;
-    top: 20px;
+    right: 10px;
+    top: 10px;
+    font-size: 26px;
     display: none; }
   .global_header.hide_close .timer, .global_header.hide_close .etc {
     opacity: 0;

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -137,7 +137,7 @@ ul, li, dl, dt, dd {
 	}
 	.header_close_btn {
 		position: absolute;
-		right: 10px;
+		right: 20px;
 		top: 10px;
 		font-size: 26px;
 		display: none;

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -137,8 +137,9 @@ ul, li, dl, dt, dd {
 	}
 	.header_close_btn {
 		position: absolute;
-		right: 20px;
-		top: 20px;
+		right: 10px;
+		top: 10px;
+		font-size: 26px;
 		display: none;
 	}
 	&.hide_close {


### PR DESCRIPTION
グローバルヘッダーのcloseボタンが非常にタップしづらかったので、
試しに大きくしてみる。

content: "\f00d"
のfont-sizeであったので、font-sizeを拡大してみた。